### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#kafka-streams
+# kafka-streams
 This is the repository for the examples of using Kafka streams covered in the blog posts: 
 
  *   [Kafka Streams - The Processor API](http://codingjunkie.net/kafka-processor-part1/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
